### PR TITLE
STR-99--BE: Keep track of and send emails when a student is no longer in a study

### DIFF
--- a/app/Http/Controllers/ParticipantController.php
+++ b/app/Http/Controllers/ParticipantController.php
@@ -2,8 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\RemoveParticipantFromStudy;
+use App\Models\Participant;
+use App\Models\User;
 use Illuminate\Http\Request;
 use App\Contracts\ParticipantContract;
+use Illuminate\Support\Facades\DB;
 class ParticipantController extends Controller
 {
     protected $participantUtility;
@@ -21,5 +25,17 @@ class ParticipantController extends Controller
         ];
 
         return $this->participantUtility->addGoodParticipantsToParticipantsTable($goodParticipants);
+    }
+
+    public function removeParticipantFromStudy(Request $request){
+
+        $user = $request->all();
+        Participant::find($user['user_id'])->delete();
+
+        $this->dispatch(new RemoveParticipantFromStudy($user));
+
+        return 'True';
+
+
     }
 }

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -20,6 +20,7 @@ class VerifyCsrfToken extends Middleware
      */
     protected $except = [
         '/loginVerification',
-        '/submitGoodParticipants'
+        '/submitGoodParticipants',
+        '/removeParticipant'
     ];
 }

--- a/app/Jobs/RemoveParticipantFromStudy.php
+++ b/app/Jobs/RemoveParticipantFromStudy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Participant;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\GenericEmail;
+use Illuminate\Support\Facades\Log;
+class RemoveParticipantFromStudy implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 3;
+    protected $user;
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $user = $this->user;
+
+        //Mail::to((env('RECIEVE_EMAIL')))->send(new GenericEmail($user));
+
+
+
+    }
+}

--- a/app/Jobs/RemoveParticipantFromStudy.php
+++ b/app/Jobs/RemoveParticipantFromStudy.php
@@ -38,7 +38,7 @@ class RemoveParticipantFromStudy implements ShouldQueue
         $user = $this->user;
 
         //Mail::to((env('RECIEVE_EMAIL')))->send(new GenericEmail($user));
-
+        //commented out until STR-97 is merged
 
 
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,3 +31,4 @@ Route::post('/setModuleProgress','ModuleProgressController@setModuleProgress');
 
 Route::post('/verifyExcelSheet', 'AdminController@checkEmailsInJson');
 Route::post('/submitGoodParticipants','ParticipantController@addGoodParticipantsToParticipantsTable');
+Route::post('/removeParticipant','ParticipantController@removeParticipantFromStudy');

--- a/tests/phpunit/ControllersTests/ParticipantControllerTest.php
+++ b/tests/phpunit/ControllersTests/ParticipantControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Participant;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use App\Jobs\RemoveParticipantFromStudy;
+
+class ParticipantControllerTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    use DatabaseMigrations;
+    /**
+     * @test
+     */
+    public function moduleComplete_sends_email_to_user_5_days_after_module_complete()
+    {
+        $data = ['user_id' => 'members:000022575'];
+        factory(Participant::class)->make(['user_id' => 'members:000022575'])
+            ->save();
+
+        Queue::fake();
+        RemoveParticipantFromStudy::dispatch($data);
+        Queue::assertPushed(RemoveParticipantFromStudy::class);
+    }
+
+    public function test_if_user_was_deleted(){
+
+        $data = ['user_id' => 'members:000022575'];
+        factory(Participant::class)->make(['user_id' => 'members:000022575'])
+            ->save();
+         Participant::find($data['user_id'])->delete();
+        $find_participant = Participant::find($data['user_id']);
+        $this->assertNull($find_participant);
+    }
+}


### PR DESCRIPTION
# Description
Deletes user from study and sends email to admin or whoever  
# Testing
Run "php artisan queue:listen --tries=1"
Open another terminal window and Run "redis-server"
Go to postman and send a user_id in the body to the route "/removeParticipant"
Go to your local db and copy a user_id in the Participants table and add it to the Postman Body
Hit send on postman
Check to see if user was deleted in DB
Check to see if an email was sent to you if 'smtp' is in your env files, or check your log if your email is set up to go to log
# Installation
'Are there any dependencies the reviewer needs to download?'
