### PR TITLE
STR-310 -- Fix `get-progress-module`  route.

### DIFF
--- a/app/Services/ModuleProgressService.php
+++ b/app/Services/ModuleProgressService.php
@@ -14,28 +14,31 @@ class ModuleProgressService implements ModuleProgressContract
 
     public function getModuleProgress($data): array
     {
+        $response = [];
         $moduleProgress = ModuleProgress::where('user_id',$data['user_id'])
                                             ->where('current_module',$data['current_module'])
-                                            ->first()
-                                            ->toArray();
-        
-        return [
-            'user_id' => $moduleProgress['user_id'],
-            'current_module' => $moduleProgress['current_module'],
-            'current_page' => $moduleProgress['current_page'],
-            'max_page' => $moduleProgress['max_page'],
-        ];
+                                            ->first();
+        if ($moduleProgress !== null) {
+            $moduleProgress->toArray();
+            $response = [
+                'user_id' => $moduleProgress['user_id'],
+                'current_module' => $moduleProgress['current_module'],
+                'current_page' => $moduleProgress['current_page'],
+                'max_page' => $moduleProgress['max_page'],
+            ];
+        }
+        return $response;
     }
 
     public function setModuleProgress($data)
     {
         $moduleProgress = ModuleProgress::updateOrCreate(
             [
-                'user_id' => $data['user_id'], 
+                'user_id' => $data['user_id'],
                 'current_module' => $data['current_module']
             ],
             [
-                'current_page' => $data['current_page'], 
+                'current_page' => $data['current_page'],
                 'max_page' => $data['max_page']
             ]
         );

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,7 @@ Route::get('/send-mail-test','MailController@sendMail');
 Route::get('/send-student-removed-email', 'StudentRemovedFromStudyController@sendStudentRemovedMail');
 
 Route::get('/user','UserGroupController@sortAuthenticatedUsers');
-Route::get('/get-module-progress/{user_id}/{current_module}','ModuleProgressController@getModuleProgress');
+Route::post('/get-module-progress','ModuleProgressController@getModuleProgress');
 Route::post('/set-module-progress','ModuleProgressController@setModuleProgress');
 
 Route::post('/verify-excel-sheet', 'AdminController@checkEmailsInJson');


### PR DESCRIPTION
# Description
This fixes an issue with the `get-progress-module` route. It was defined as a `GET` request but everywhere else it was used as a `POST` request.
  
# Testing
To test this PR go into `STR-300-hack` and follow the instructions in #168 

# Installation
See instructions in #168 
