### PR TITLE
Add subject line, remove participant  and more clean-up

### DIFF
--- a/app/Console/Commands/DeadlineReminderCommand.php
+++ b/app/Console/Commands/DeadlineReminderCommand.php
@@ -44,7 +44,7 @@ class DeadlineReminderCommand extends Command
         // Let's get the users that only have an actual Module
         $users = User::with(['moduleProgress' => function ($q) {
             $q->orderBy('created_at', 'DESC')->first();
-        }, 'participant'])->whereHas('moduleProgress')->get();
+        }])->whereHas('moduleProgress')->get();
         // get calls always return something
         if (!empty($users)) {
             foreach ($users as $user) {
@@ -57,6 +57,7 @@ class DeadlineReminderCommand extends Command
                     }
                     if ($dayCheck === 0) {
                         if ($currentModule->current_page === 0 && $currentModule->max_page === 0) {
+                            $user->participant()->delete();
                             Mail::to((env('RECIEVE_EMAIL')))->send(new StudentRemovedFromStudyAdminEmail($user));
                         }
                     }

--- a/app/Console/Commands/LoginReminderCommand.php
+++ b/app/Console/Commands/LoginReminderCommand.php
@@ -47,7 +47,6 @@ class LoginReminderCommand extends Command
         if (!empty($users)) {
             foreach ($users as $user) {
                 $dayCheck = (Carbon::now()->diffInDays($user->getUserGroup->created_at));
-
                 if ($dayCheck === 3) {
                     // send out the email.
                     Mail::to($user->email)->send(new UserHasntLoggedInEmail($user));

--- a/app/Mail/GenericEmail.php
+++ b/app/Mail/GenericEmail.php
@@ -32,7 +32,7 @@ class GenericEmail extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.generic');
+        return $this->subject(config('mail.from.name'))->view('mail.generic');
 
     }
 }

--- a/app/Mail/InfoFromModuleEmail.php
+++ b/app/Mail/InfoFromModuleEmail.php
@@ -25,6 +25,6 @@ class InfoFromModuleEmail extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.InfoFromModuleEmail');
+        return $this->subject(config('mail.from.name'). ' progress.')->view('mail.InfoFromModuleEmail');
     }
 }

--- a/app/Mail/NewModuleAvailable.php
+++ b/app/Mail/NewModuleAvailable.php
@@ -30,6 +30,6 @@ class NewModuleAvailable extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.NewModuleAvailable');
+        return $this->subject(config('mail.from.name'). ' new module is ready for you.')->view('mail.NewModuleAvailable');
     }
 }

--- a/app/Mail/RandomizationEmail.php
+++ b/app/Mail/RandomizationEmail.php
@@ -33,6 +33,6 @@ class RandomizationEmail extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.randomizationEmail');
+        return $this->subject(config('mail.from.name'). ' welcome to the app.')->view('mail.randomizationEmail');
     }
 }

--- a/app/Mail/StudentRemovedFromStudy.php
+++ b/app/Mail/StudentRemovedFromStudy.php
@@ -28,6 +28,6 @@ class StudentRemovedFromStudy extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.StudentRemovedFromStudyEmail');
+        return $this->subject(config('mail.from.name'). ' you have been removed.')->view('mail.StudentRemovedFromStudyEmail');
     }
 }

--- a/app/Mail/StudentRemovedFromStudyAdminEmail.php
+++ b/app/Mail/StudentRemovedFromStudyAdminEmail.php
@@ -30,6 +30,6 @@ class StudentRemovedFromStudyAdminEmail extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.StudentRemovedFromStudyAdminEmail');
+        return $this->subject(config('mail.from.name'). ' student removed from study.')->view('mail.StudentRemovedFromStudyAdminEmail');
     }
 }

--- a/app/Mail/UserCompletesModuleEmailToAdmin.php
+++ b/app/Mail/UserCompletesModuleEmailToAdmin.php
@@ -37,6 +37,6 @@ class UserCompletesModuleEmailToAdmin extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.UserCompletesModuleEmailToAdmin');
+        return $this->subject(config('mail.from.name'). ' module completion email.')->view('mail.UserCompletesModuleEmailToAdmin');
     }
 }

--- a/app/Mail/UserCompletesModuleEmailToStudent.php
+++ b/app/Mail/UserCompletesModuleEmailToStudent.php
@@ -37,6 +37,6 @@ class UserCompletesModuleEmailToStudent extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.UserCompletesModuleEmailToStudent');
+        return $this->subject(config('mail.from.name'). ' module completion confirmation')->view('mail.UserCompletesModuleEmailToStudent');
     }
 }

--- a/app/Mail/UserHasntLoggedInEmail.php
+++ b/app/Mail/UserHasntLoggedInEmail.php
@@ -30,6 +30,6 @@ class UserHasntLoggedInEmail extends Mailable
      */
     public function build()
     {
-        return $this->view('mail.UserHasntLoggedInEmail');
+        return $this->subject(config('mail.from.name').' Log-in Reminder')->view('mail.UserHasntLoggedInEmail');
     }
 }

--- a/app/Mail/UserRunningOutOfTimeEmail.php
+++ b/app/Mail/UserRunningOutOfTimeEmail.php
@@ -21,6 +21,6 @@ class UserRunningOutOfTimeEmail extends Mailable
 
     public function build()
     {
-        return $this->view('mail.UserRunningOutOfTimeEmail');
+        return $this->subject(config('mail.from.name').' module completion reminder.')->view('mail.UserRunningOutOfTimeEmail');
     }
 }

--- a/resources/views/mail/randomization.blade.php
+++ b/resources/views/mail/randomization.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
 Thank you for participating in the iSTART substance use prevention study.
 <br>
-@if ($user->getUserGroup->user_group === 'prevention')
+@if ($userInUserGroup->user_group === 'prevention')
     You have been randomized into Group 1: Prevention
     <br>
     You will participate in 5 substance use prevention modules (approximately 1 module per week). You will be able to access the first module immediately.
@@ -9,7 +9,7 @@ Thank you for participating in the iSTART substance use prevention study.
     Each module will last about 15 minutes and will be released 5 days after the previous module is completed. You will have 7 days to complete each module in order to continue in the study and receive your gift cards.
     <br>
     After the 5th and final module, you will receive an EXIT survey via email, and then a 90-day follow-up survey.
-@elseif ($user->getUserGroup->user_group === 'comparison')
+@elseif ($userInUserGroup->user_group === 'comparison')
     You have been randomized into Group 2: Comparison
     <br>
     You will participate in one substance use prevention module, available immediately.


### PR DESCRIPTION
# Description
Subject line on all emails now start with `iSTART web app`, remove the participant from study, and more clean-up
  
# Testing
Test the emails that go out with the following artisan commands
+ `php artisan istart:login-reminder`
+ `php artisan istart:deadline-reminder`
+ `php artisan istart:new-module`

# Installation
None
