### PR TITLE
HOTFIX-12-20-2019 -- DeadlineReminder

### DIFF
--- a/app/Console/Commands/DeadlineReminderCommand.php
+++ b/app/Console/Commands/DeadlineReminderCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Mail;
 use App\Mail\StudentRemovedFromStudyAdminEmail;
 use App\Mail\UserRunningOutOfTimeEmail;
 use App\Models\User;
+use Carbon\Carbon;
 
 class DeadlineReminderCommand extends Command
 {
@@ -51,17 +52,24 @@ class DeadlineReminderCommand extends Command
         if (!empty($users)) {
             foreach ($users as $user) {
                 foreach ($user->moduleProgress as $currentModule) {
-                    $dayCheck = $currentModule->created_at->diffInDays($currentModule->expiration_date);
-                    if ($dayCheck === 2 || $dayCheck === 1) {
-                        if ($currentModule->current_page !== $currentModule->max_page) {
-                            // send out the email.
-                            Mail::to($user->email)->cc(env('RECEIVE_EMAIL'))->send(new UserRunningOutOfTimeEmail($user, $currentModule->current_module));
+                    // we want to check today's date vs the expiration date of the module.
+                    $dayCheck = Carbon::now()->diffInDays($currentModule->expiration_date);
+                    if ($user->getUserGroup->user_group !== 'comparison') {
+                        if ($dayCheck === 2 || $dayCheck === 1) {
+                            if ($currentModule->current_page !== $currentModule->max_page) {
+                                // send out the email.
+                                Mail::to($user->email)->cc(env('RECEIVE_EMAIL'))->send(new UserRunningOutOfTimeEmail($user, $currentModule->current_module));
+                            }
                         }
-                    }
-                    if ($dayCheck === 0) {
-                        if ($currentModule->current_page === 0 && $currentModule->max_page === 0) {
-                            $user->participant()->delete();
-                            Mail::to(env('RECEIVE_EMAIL'))->send(new StudentRemovedFromStudyAdminEmail($user, $currentModule->current_module));
+                        if ($dayCheck === 0) {
+                            if ($currentModule->current_page === 0 && $currentModule->max_page === 0) {
+                                $user->participant()->delete();
+                                Mail::to(env('RECEIVE_EMAIL'))->send(new StudentRemovedFromStudyAdminEmail($user, $currentModule->current_module));
+                            }
+                        }
+                    } else {
+                        if ($dayCheck === 10 || $daCheck === 3)  {
+                            Mail::to($user->email)->cc(env('RECEIVE_EMAIL'))->send(new UserRunningOutOfTimeEmail($user, $currentModule->current_module));
                         }
                     }
                 }


### PR DESCRIPTION
# Description
Fixes the reminders to use today's date and checks against the expiration date because the module creation date is not a very good value to use. Also made a very specific case for when the user_group is comparison.
  
# Testing
Make your self a module on the database, make it so that it expires 2 or 1 day from now, then run `php artisan istart:deadline-reminder` you should get emailed.

# Installation
None
